### PR TITLE
205 fix ssm activation error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,7 @@ resource "aws_ssm_activation" "ec2" {
   iam_role           = join("", aws_iam_role.ec2.*.id)
   registration_limit = var.autoscale_max
   tags               = module.this.tags
-  depends_on = [aws_elastic_beanstalk_environment.default]
+  depends_on         = [aws_elastic_beanstalk_environment.default]
 }
 
 data "aws_iam_policy_document" "default" {

--- a/main.tf
+++ b/main.tf
@@ -161,6 +161,7 @@ resource "aws_ssm_activation" "ec2" {
   iam_role           = join("", aws_iam_role.ec2.*.id)
   registration_limit = var.autoscale_max
   tags               = module.this.tags
+  depends_on = [aws_elastic_beanstalk_environment.default]
 }
 
 data "aws_iam_policy_document" "default" {


### PR DESCRIPTION
## what
* Added `depends_on = [aws_elastic_beanstalk_environment.default]` to `aws_ssm_activation.ec2`

## why
* As stated in [this comment](https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment/issues/205#issuecomment-1302326948) on the issue #205 it does actually solve the problem.

## references
* Closes #205


## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

